### PR TITLE
add njit based on presorting

### DIFF
--- a/exetera/core/importer.py
+++ b/exetera/core/importer.py
@@ -212,7 +212,7 @@ class DatasetImporter:
                                     error = "'{}' not valid: must be one of {} for field '{}'"
                                     raise KeyError(
                                         error.format(f, categorical_map, available_keys[i_f]))
-                                f = categorical_map[f]
+                                #f = categorical_map[f]
                             field_chunk_list[i_df][chunk_index] = f
                         chunk_index += 1
                         if chunk_index == chunk_size:
@@ -236,3 +236,6 @@ class DatasetImporter:
 
             print(f"{i_r} rows parsed in {time.time() - time0}s")
 
+        print('=======00======')
+        print(time.time() - time0)
+        print('=======00======')


### PR DESCRIPTION
fix #115 

Looking for feedback:

Tried to optimize based on presorting as suggested. However, after the changes are implemented it now takes 126s compared to 16s (the original solution) to process all the rows.

I'm looking for feedback on the implementation to verify if I have implemented it in the way you suggested, or if I missed some important detail that would help improve performance. 

I can also look at leveraging a trie instead, to see if that could help improve performance. Let me know your thoughts.  
