### PR TITLE
Datetime Fixes (that don't actually work yet)

### DIFF
--- a/exetera/core/fields.py
+++ b/exetera/core/fields.py
@@ -20,6 +20,7 @@ from exetera.core.abstract_types import Field
 from exetera.core.data_writer import DataWriter
 from exetera.core import operations as ops
 from exetera.core import validation as val
+from exetera.core import utils
 
 class HDF5Field(Field):
     def __init__(self, session, group, dataframe, write_enabled=False):
@@ -1974,10 +1975,10 @@ class DateTimeImporter:
         for i, v in enumerate(values):
             if len(v) == 32:
                 ts = datetime.strptime(v, '%Y-%m-%d %H:%M:%S.%f%z')
-                results[i] = ts.timestamp()
+                results[i] = utils.to_timestamp(ts)
             elif len(v) == 25:
                 ts = datetime.strptime(v, '%Y-%m-%d %H:%M:%S%z')
-                results[i] = ts.timestamp()
+                results[i] = utils.to_timestamp(ts)
             else:
                 if self._optional is True and len(v) == 0:
                     results[i] = np.nan
@@ -2019,7 +2020,7 @@ class DateImporter:
                 timestamps[i] = np.nan
             else:
                 ts = datetime.strptime(value, '%Y-%m-%d')
-                timestamps[i] = ts.timestamp()
+                timestamps[i] = utils.to_timestamp(ts)
         self._field.data.write_part(timestamps)
 
     def complete(self):

--- a/exetera/core/readerwriter.py
+++ b/exetera/core/readerwriter.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from exetera.core import persistence as pers
 from exetera.core.data_writer import DataWriter
+from exetera.core import utils
 
 
 class Reader:
@@ -633,7 +634,7 @@ class DateTimeWriter(Writer):
                                   int(value[11:13]), int(value[14:16]), int(value[17:19]))
                 else:
                     raise ValueError(f"Date field '{self.field}' has unexpected format '{value}'")
-                timestamps[i] = ts.timestamp()
+                timestamps[i] = utils.to_timestamp(ts)
         DataWriter.write(self.field, 'values', timestamps, len(timestamps))
 
     def flush(self):
@@ -673,7 +674,7 @@ class DateWriter(Writer):
                 timestamps[i] = 0
             else:
                 ts = datetime.strptime(value.decode(), '%Y-%m-%d')
-                timestamps[i] = ts.timestamp()
+                timestamps[i] = utils.to_timestamp(ts)
         DataWriter.write(self.field, 'values', timestamps, len(timestamps))
 
     def flush(self):

--- a/exetera/core/utils.py
+++ b/exetera/core/utils.py
@@ -12,7 +12,7 @@
 import time
 from collections import defaultdict
 import csv
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 
 import numpy as np
@@ -85,6 +85,30 @@ def string_to_datetime(field):
             ts = datetime.strptime(field, '%Y-%m-%d')
 
     return ts
+
+
+def to_timestamp(dt):
+    """
+    Convert the date time object `dt` to a timestamp value in a portable way. If `dt` has no timezone information
+    UTC will be used to determine the timestamp.
+    """
+    # convert to UTC if needed
+    # dt = dt if dt.tzinfo is not None else dt.astimezone(timezone.utc)
+    if dt.tzinfo is None:
+        # because datetime.astimezone is also bugged
+        dt=dt.replace(tzinfo=timezone.utc)
+        
+    return (dt - datetime(1970, 1, 1, tzinfo=dt.tzinfo)).total_seconds()
+    
+    
+def from_timestamp(ts,tzinfo=None):
+    """
+    Convert the UTC timestamp float value `ts` to a datetime object in a portable way.  
+    """
+    # select UTC if no timezone specified
+    tzinfo=tzinfo if tzinfo is not None else timezone.utc
+        
+    return datetime(1970, 1, 1, tzinfo=tzinfo) + timedelta(seconds=ts)
 
 
 def build_histogram(dataset, filtered_records=None, tx=None):

--- a/exetera/core/utils.py
+++ b/exetera/core/utils.py
@@ -18,8 +18,11 @@ from io import StringIO
 import numpy as np
 from numba import njit
 
+import pytz
+
 
 SECONDS_PER_DAY = 86400
+LOCAL_TIMEZONE = datetime.now(timezone.utc).astimezone().tzinfo
 
 
 def validate_file_exists(file_name):
@@ -93,13 +96,20 @@ def to_timestamp(dt):
     UTC will be used to determine the timestamp.
     """
     # convert to UTC if needed
-    # dt = dt if dt.tzinfo is not None else dt.astimezone(timezone.utc)
-    if dt.tzinfo is None:
-        # because datetime.astimezone is also bugged
-        dt=dt.replace(tzinfo=timezone.utc)
+#     if dt.tzinfo is None:
+# #         dt = dt.astimezone(timezone.utc)
+#         # because datetime.astimezone is also bugged
+# #         dt=dt.replace(tzinfo=timezone.utc)
+#         dt=pytz.utc.localize(dt)
+
+    ts = (dt - datetime(1970, 1, 1, tzinfo=dt.tzinfo)).total_seconds()
+
+    ltime=time.localtime(ts)
+    if ltime.tm_isdst:
+        return ts-3600
+    else:
+        return ts
         
-    return (dt - datetime(1970, 1, 1, tzinfo=dt.tzinfo)).total_seconds()
-    
     
 def from_timestamp(ts,tzinfo=None):
     """

--- a/exetera/core/utils.py
+++ b/exetera/core/utils.py
@@ -23,7 +23,7 @@ import pytz
 
 
 SECONDS_PER_DAY = 86400
-LOCAL_TIMEZONE = datetime.now(timezone.utc).astimezone().tzinfo
+DATE_TIME_EPOCH = datetime(1970,1,1,tzinfo=timezone.utc)
 
 
 def validate_file_exists(file_name):
@@ -96,31 +96,24 @@ def to_timestamp(dt):
     Convert the date time object `dt` to a timestamp value in a portable way. If `dt` has no timezone information
     UTC will be used to determine the timestamp.
     """
-    if platform.system().lower() != "windows":
+    if "windows" not in platform.system().lower():
         return dt.timestamp()
     
-    # convert to UTC if needed
-    if dt.tzinfo is None:
-# #         dt = dt.astimezone(timezone.utc)
-#         # because datetime.astimezone is also bugged
-# #         dt=dt.replace(tzinfo=timezone.utc)
-
-        
-
-    return (dt - datetime(1970, 1, 1, tzinfo=dt.tzinfo)).total_seconds()
+    return (dt - DATE_TIME_EPOCH.replace(tzinfo=dt.tzinfo)).total_seconds()
 
 
 def from_timestamp(ts,tzinfo=None):
     """
     Convert the UTC timestamp float value `ts` to a datetime object in a portable way.  
     """
-    if platform.system().lower() != "windows":
-        return datetime.fromtimestamp(ts, tzinfo)
-        
+    
     # select UTC if no timezone specified
     tzinfo=tzinfo if tzinfo is not None else timezone.utc
+    
+    if "windows" not in platform.system().lower():
+        return datetime.fromtimestamp(ts, tzinfo)
         
-    return datetime(1970, 1, 1, tzinfo=tzinfo) + timedelta(seconds=ts)
+    return DATE_TIME_EPOCH.replace(tzinfo=tzinfo) + timedelta(seconds=ts)
 
 
 def build_histogram(dataset, filtered_records=None, tx=None):

--- a/exetera/core/utils.py
+++ b/exetera/core/utils.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import platform
 import time
 from collections import defaultdict
 import csv
@@ -95,26 +96,27 @@ def to_timestamp(dt):
     Convert the date time object `dt` to a timestamp value in a portable way. If `dt` has no timezone information
     UTC will be used to determine the timestamp.
     """
+    if platform.system().lower() != "windows":
+        return dt.timestamp()
+    
     # convert to UTC if needed
-#     if dt.tzinfo is None:
+    if dt.tzinfo is None:
 # #         dt = dt.astimezone(timezone.utc)
 #         # because datetime.astimezone is also bugged
 # #         dt=dt.replace(tzinfo=timezone.utc)
-#         dt=pytz.utc.localize(dt)
 
-    ts = (dt - datetime(1970, 1, 1, tzinfo=dt.tzinfo)).total_seconds()
-
-    ltime=time.localtime(ts)
-    if ltime.tm_isdst:
-        return ts-3600
-    else:
-        return ts
         
-    
+
+    return (dt - datetime(1970, 1, 1, tzinfo=dt.tzinfo)).total_seconds()
+
+
 def from_timestamp(ts,tzinfo=None):
     """
     Convert the UTC timestamp float value `ts` to a datetime object in a portable way.  
     """
+    if platform.system().lower() != "windows":
+        return datetime.fromtimestamp(ts, tzinfo)
+        
     # select UTC if no timezone specified
     tzinfo=tzinfo if tzinfo is not None else timezone.utc
         

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -7,6 +7,7 @@ from exetera.core import session, fields
 from exetera.core.abstract_types import DataFrame
 from io import BytesIO
 from exetera.core.dataset import HDF5Dataset, copy, move
+from exetera.core import utils
 
 
 class TestDataSet(unittest.TestCase):
@@ -102,9 +103,9 @@ class TestDataSet(unittest.TestCase):
         ncontents2 = np.array([5, 6, 7, 8], dtype=np.int32)
         from datetime import datetime as D
         tcontents1 = [D(2020, 1, 1), D(2020, 1, 2), D(2020, 1, 3), D(2020, 1, 4)]
-        tcontents1 = np.array([d.timestamp() for d in tcontents1])
+        tcontents1 = np.array([utils.to_timestamp(d) for d in tcontents1])
         tcontents2 = [D(2021, 1, 1), D(2021, 1, 2), D(2021, 1, 3), D(2021, 1, 4)]
-        tcontents2 = np.array([d.timestamp() for d in tcontents2])
+        tcontents2 = np.array([utils.to_timestamp(d) for d in tcontents2])
 
         bio = BytesIO()
         with session.Session() as s:

--- a/tests/test_date_time_helpers.py
+++ b/tests/test_date_time_helpers.py
@@ -6,7 +6,7 @@ from datetime import timedelta as T
 import numpy as np
 
 from exetera.processing import date_time_helpers as dth
-
+from exetera.core import utils
 
 class S:
     def __init__(self, start, end, expected=None, message=None):
@@ -139,13 +139,13 @@ class TestDateTimeHelpers(unittest.TestCase):
         self._do_scenario_test(scenarios, 'days', -28)
         self._do_scenario_test(scenarios, 'week', -4)
         self._do_scenario_test(scenarios, 'weeks', -4)
-
+        
 
 class TestGetDays(unittest.TestCase):
 
     def _setup_timestamps(self, start, delta, count):
 
-        return np.asarray([(start + T(seconds=delta * i)).timestamp()
+        return np.asarray([utils.to_timestamp(start + T(seconds=delta * i))
                          for i in range(count)], dtype=np.float64)
 
     def _get_expected(self, timestamps, filter_field=None, start_date=None, end_date=None):
@@ -176,7 +176,7 @@ class TestGetDays(unittest.TestCase):
 
     def test_get_days_delimiting_dates(self):
         tss = self._setup_timestamps(D(2020, 5, 10, 23, 55, 0, 123500), 30000, 11)
-        start_date = D(2020, 5, 11).timestamp()
+        start_date = utils.to_timestamp(D(2020, 5, 11))
         actual = dth.get_days(tss, start_date=start_date)
         expected = self._get_expected(tss, start_date=start_date)
         self.assertListEqual(expected.tolist(), actual[0].tolist())

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -8,7 +8,7 @@ import h5py
 from exetera.core import session
 from exetera.core import fields
 from exetera.core import persistence as per
-
+from exetera.core import utils
 
 class TestFieldExistence(unittest.TestCase):
 
@@ -132,7 +132,7 @@ class TestIsSorted(unittest.TestCase):
             d = D(2020, 5, 10)
             vals = [d + T(seconds=50000), d - T(days=280), d + T(weeks=2), d + T(weeks=250),
                     d - T(weeks=378), d + T(hours=2897), d - T(days=23), d + T(minutes=39873)]
-            vals = [v.timestamp() for v in vals]
+            vals = [utils.to_timestamp(v) for v in vals]
             f.data.write(vals)
             self.assertFalse(f.is_sorted())
 
@@ -666,7 +666,7 @@ class TestFieldApplyFilter(unittest.TestCase):
         from datetime import datetime as D
         data = [D(2020, 1, 1), D(2021, 5, 18), D(2950, 8, 17), D(1840, 10, 11),
                 D(2110, 11, 1), D(2002, 3, 3), D(2018, 2, 28), D(2400, 9, 1)]
-        data = np.asarray([d.timestamp() for d in data], dtype=np.float64)
+        data = np.asarray([utils.to_timestamp(d) for d in data], dtype=np.float64)
         filt = np.array([0, 1, 0, 1, 0, 1, 0, 1], dtype=bool)
         expected = data[filt].tolist()
 
@@ -903,7 +903,7 @@ class TestFieldApplyIndex(unittest.TestCase):
         from datetime import datetime as D
         data = [D(2020, 1, 1), D(2021, 5, 18), D(2950, 8, 17), D(1840, 10, 11),
                 D(2110, 11, 1), D(2002, 3, 3), D(2018, 2, 28), D(2400, 9, 1)]
-        data = np.asarray([d.timestamp() for d in data], dtype=np.float64)
+        data = np.asarray([utils.to_timestamp(d) for d in data], dtype=np.float64)
         indices = np.array([7, 0, 6, 1, 5, 2, 4, 3], dtype=np.int32)
         expected = data[indices].tolist()
         bio = BytesIO()
@@ -1061,7 +1061,7 @@ class TestFieldApplySpansCount(unittest.TestCase):
         from datetime import datetime as D
         src_data = [D(2020, 1, 1), D(2021, 5, 18), D(2950, 8, 17), D(1840, 10, 11),
                     D(2021, 1, 1), D(2022, 5, 18), D(2951, 8, 17), D(1841, 10, 11)]
-        src_data = np.asarray([d.timestamp() for d in src_data], dtype=np.float64)
+        src_data = np.asarray([utils.to_timestamp(d) for d in src_data], dtype=np.float64)
 
         expected = src_data[[0, 2, 3, 6]].tolist()
         self._test_apply_spans_src(spans, src_data, expected,
@@ -1166,7 +1166,7 @@ class TestFieldCreateLike(unittest.TestCase):
     def test_timestamp_field_create_like(self):
         from datetime import datetime as D
         data = [D(2020, 1, 1), D(2021, 5, 18), D(2950, 8, 17), D(1840, 10, 11)]
-        data = np.asarray([d.timestamp() for d in data], dtype=np.float64)
+        data = np.asarray([utils.to_timestamp(d) for d in data], dtype=np.float64)
 
         bio = BytesIO()
         with session.Session() as s:
@@ -1253,7 +1253,7 @@ class TestFieldCreateLikeWithGroups(unittest.TestCase):
     def test_timestamp_field_create_like(self):
         from datetime import datetime as D
         data = [D(2020, 1, 1), D(2021, 5, 18), D(2950, 8, 17), D(1840, 10, 11)]
-        data = np.asarray([d.timestamp() for d in data], dtype=np.float64)
+        data = np.asarray([utils.to_timestamp(d) for d in data], dtype=np.float64)
 
         bio = BytesIO()
         with h5py.File(bio, 'w') as ds:

--- a/tests/test_journalling.py
+++ b/tests/test_journalling.py
@@ -12,6 +12,7 @@ from exetera.core import session
 from exetera.core import fields
 from exetera.core import persistence as per
 from exetera.core import journal
+from exetera.core import utils
 
 
 class Schema:
@@ -23,9 +24,9 @@ class TestSessionMerge(unittest.TestCase):
 
     def test_journal_full(self):
 
-        ts1 = datetime(2020, 8, 1).timestamp()
-        ts2 = datetime(2020, 9, 1).timestamp()
-        tsf = ops.MAX_DATETIME.timestamp()
+        ts1 = utils.to_timestamp(datetime(2020, 8, 1))
+        ts2 = utils.to_timestamp(datetime(2020, 9, 1))
+        tsf = utils.to_timestamp(ops.MAX_DATETIME)
 
         d1_id = np.chararray(9)
         d1_id[:] = np.asarray(['a', 'a', 'b', 'b', 'c', 'e', 'e', 'e', 'g'])

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -528,7 +528,7 @@ class TestPersistence(unittest.TestCase):
         with h5py.File(bio, 'r') as hf:
             foo = rw.TimestampReader(datastore, hf['foo'])
             actual = [f for f in foo[:]]
-            self.assertEqual([v.timestamp() for v in values], actual)
+            self.assertEqual([utils.to_timestamp(v) for v in values], actual)
 
 
     def test_new_timestamp_reader(self):
@@ -541,7 +541,7 @@ class TestPersistence(unittest.TestCase):
         deltas = [random.randint(10, 1000) for _ in range(95)]
         values = [dt + timedelta(seconds=d) for d in deltas]
         svalues = [str(v).encode() for v in values]
-        tsvalues = np.asarray([v.timestamp() for v in values], dtype=np.float64)
+        tsvalues = np.asarray([utils.to_timestamp(v) for v in values], dtype=np.float64)
 
         with h5py.File(bio, 'w') as hf:
             foo = rw.DateTimeWriter(datastore, hf, 'foo', ts)
@@ -568,7 +568,7 @@ class TestPersistence(unittest.TestCase):
         deltas = [random.randint(10, 1000) for _ in range(95)]
         values = [dt + timedelta(seconds=d) for d in deltas]
         svalues = [str(v).encode() for v in values]
-        tsvalues = np.asarray([v.timestamp() for v in values], dtype=np.float64)
+        tsvalues = np.asarray([utils.to_timestamp(v) for v in values], dtype=np.float64)
 
         with h5py.File(bio, 'w') as hf:
             rw.DateTimeWriter(datastore, hf, 'foo', ts).write(svalues)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -9,6 +9,7 @@ from exetera.core import session
 from exetera.core import fields
 from exetera.core import dataframe
 from exetera.core import persistence as per
+from exetera.core import utils
 
 
 class TestCreateThenLoadBetweenSessionsOld(unittest.TestCase):
@@ -74,7 +75,7 @@ class TestCreateThenLoadBetweenSessionsOld(unittest.TestCase):
         from datetime import datetime as D
         bio = BytesIO()
         contents = [D(2021, 2, 6), D(2020, 11, 5), D(2974, 8, 1), D(1873, 12, 28)]
-        contents = [c.timestamp() for c in contents]
+        contents = [utils.to_timestamp(c) for c in contents]
 
         with session.Session() as s:
             with h5py.File(bio, 'w') as src:
@@ -1166,7 +1167,9 @@ class TestSessionImporters(unittest.TestCase):
             im = fields.DateImporter(s, hf, 'x')
             im.write(values)
             f = s.get(hf['x'])
-            self.assertListEqual(
-                [datetime(year=int(v[0:4]), month=int(v[5:7]), day=int(v[8:10])
-                          ).timestamp() for v in values],
-                f.data[:].tolist())
+            
+            ts_list = [
+                utils.to_timestamp(datetime(year=int(v[0:4]), month=int(v[5:7]), day=int(v[8:10]))) for v in values
+            ] 
+            
+            self.assertListEqual(ts_list, f.data[:].tolist())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,30 +10,37 @@
 # limitations under the License.
 
 import unittest
+import platform
 from datetime import datetime, timezone, timedelta
 
 import numpy as np
 
 from exetera.core.utils import (
-    find_longest_sequence_of, to_escaped, bytearray_to_escaped, to_timestamp, from_timestamp
+    DATE_TIME_EPOCH,
+    find_longest_sequence_of,
+    to_escaped,
+    bytearray_to_escaped,
+    to_timestamp,
+    from_timestamp,
 )
+
+is_win = "windows" in platform.system().lower()
 
 
 class TestUtils(unittest.TestCase):
-
     def test_find_longest_sequence_of(self):
-        self.assertEqual(find_longest_sequence_of('', '`'), 0)
-        self.assertEqual(find_longest_sequence_of('foo', '`'), 0)
-        self.assertEqual(find_longest_sequence_of('`foo`', '`'), 1)
-        self.assertEqual(find_longest_sequence_of('f`oo', '`'), 1)
-        self.assertEqual(find_longest_sequence_of('foo `` bar`', '`'), 2)
-        self.assertEqual(find_longest_sequence_of('``foo`` bar ```', '`'), 3)
+        self.assertEqual(find_longest_sequence_of("", "`"), 0)
+        self.assertEqual(find_longest_sequence_of("foo", "`"), 0)
+        self.assertEqual(find_longest_sequence_of("`foo`", "`"), 1)
+        self.assertEqual(find_longest_sequence_of("f`oo", "`"), 1)
+        self.assertEqual(find_longest_sequence_of("foo `` bar`", "`"), 2)
+        self.assertEqual(find_longest_sequence_of("``foo`` bar ```", "`"), 3)
 
     def test_csv_encode_decode(self):
         import csv
         from io import StringIO
 
-        src = ['A', '"B', 'C,D', 'E"F']
+        src = ["A", '"B', "C,D", 'E"F']
         print(src)
         with StringIO() as s:
             csvw = csv.writer(s)
@@ -47,96 +54,93 @@ class TestUtils(unittest.TestCase):
         print(result)
 
     def test_to_escaped(self):
-        self.assertEqual(to_escaped(''), '')
-        self.assertEqual(to_escaped('a'), 'a')
-        self.assertEqual(to_escaped('a,b'), '"a,b"')
+        self.assertEqual(to_escaped(""), "")
+        self.assertEqual(to_escaped("a"), "a")
+        self.assertEqual(to_escaped("a,b"), '"a,b"')
         self.assertEqual(to_escaped('a"b'), '"a""b"')
         self.assertEqual(to_escaped('"a","b"'), '"""a"",""b"""')
         self.assertEqual(to_escaped(',",'), '","","')
 
     def test_bytearray_to_escaped(self):
-        src = np.frombuffer(b'abcd', dtype='S1')
-        dest = np.zeros(10, dtype='S1')
+        src = np.frombuffer(b"abcd", dtype="S1")
+        dest = np.zeros(10, dtype="S1")
+        self.assertTrue(np.array_equal(dest[: bytearray_to_escaped(src, dest)], np.frombuffer(b"abcd", dtype="S1")))
+        src = np.frombuffer(b"ab,cd", dtype="S1")
+        dest = np.zeros(10, dtype="S1")
+        self.assertTrue(np.array_equal(dest[: bytearray_to_escaped(src, dest)], np.frombuffer(b'"ab,cd"', dtype="S1")))
+        src = np.frombuffer(b'ab"cd', dtype="S1")
+        dest = np.zeros(10, dtype="S1")
+        self.assertTrue(np.array_equal(dest[: bytearray_to_escaped(src, dest)], np.frombuffer(b'"ab""cd"', dtype="S1")))
+        src = np.frombuffer(b'"ab","cd"', dtype="S1")
+        dest = np.zeros(20, dtype="S1")
         self.assertTrue(
-            np.array_equal(dest[:bytearray_to_escaped(src, dest)],
-                           np.frombuffer(b'abcd', dtype='S1')))
-        src = np.frombuffer(b'ab,cd', dtype='S1')
-        dest = np.zeros(10, dtype='S1')
-        self.assertTrue(
-            np.array_equal(dest[:bytearray_to_escaped(src, dest)],
-                           np.frombuffer(b'"ab,cd"', dtype='S1')))
-        src = np.frombuffer(b'ab"cd', dtype='S1')
-        dest = np.zeros(10, dtype='S1')
-        self.assertTrue(
-            np.array_equal(dest[:bytearray_to_escaped(src, dest)],
-                           np.frombuffer(b'"ab""cd"', dtype='S1')))
-        src = np.frombuffer(b'"ab","cd"', dtype='S1')
-        dest = np.zeros(20, dtype='S1')
-        self.assertTrue(
-            np.array_equal(dest[:bytearray_to_escaped(src, dest)],
-                           np.frombuffer(b'"""ab"",""cd"""', dtype='S1')))
+            np.array_equal(dest[: bytearray_to_escaped(src, dest)], np.frombuffer(b'"""ab"",""cd"""', dtype="S1"))
+        )
 
-        src1 = np.frombuffer(b'ab"cd', dtype='S1')
-        src2 = np.frombuffer(b'"ab","cd"', dtype='S1')
-        dest = np.zeros(30, dtype='S1')
+        src1 = np.frombuffer(b'ab"cd', dtype="S1")
+        src2 = np.frombuffer(b'"ab","cd"', dtype="S1")
+        dest = np.zeros(30, dtype="S1")
         len1 = bytearray_to_escaped(src1, dest)
         len2 = bytearray_to_escaped(src2, dest[len1:], dest_start=len1)
-        self.assertTrue(
-            np.array_equal(dest[:len1 + len2],
-                           np.frombuffer(b'"ab""cd""""ab"",""cd"""', dtype='S1')))
+        self.assertTrue(np.array_equal(dest[: len1 + len2], np.frombuffer(b'"ab""cd""""ab"",""cd"""', dtype="S1")))
 
     def test_to_timestamp_past(self):
-        n=datetime(2020,1,4,1,2,3)  # winter time
-        ts=n.timestamp()
-        
-        self.assertAlmostEqual(ts, to_timestamp(n),5)
+        n = datetime(2020, 1, 4, 1, 2, 3)  # winter time
+        ts = n.timestamp()
+
+        self.assertAlmostEqual(ts, to_timestamp(n), 5)
 
     def test_to_timestamp_past_dst(self):
-        n=datetime(2020,6,4,1,2,3)  # daylight savings time
-        ts=n.timestamp()
-        
-        self.assertAlmostEqual(ts, to_timestamp(n),5)
+        n = datetime(2020, 6, 4, 1, 2, 3)  # daylight savings time
+        ts = n.timestamp()
+
+        self.assertAlmostEqual(ts, to_timestamp(n), 5)
 
     def test_to_timestamp_future(self):
-        n=datetime(2050,1,4,1,2,3)  # winter time
-        ts=n.timestamp()
-        
-        self.assertAlmostEqual(ts, to_timestamp(n),5)
+        n = datetime(2050, 1, 4, 1, 2, 3)  # winter time
+        ts = n.timestamp()
+
+        self.assertAlmostEqual(ts, to_timestamp(n), 5)
 
     def test_to_timestamp_future_dst(self):
-        n=datetime(2050,6,4,1,2,3)  # daylight savings time
-        ts=n.timestamp()
-        
-        self.assertAlmostEqual(ts, to_timestamp(n),5)
-        
+        n = datetime(2050, 6, 4, 1, 2, 3)  # daylight savings time
+        ts = n.timestamp()
+
+        self.assertAlmostEqual(ts, to_timestamp(n), 5)
+
     def test_to_timestamp_pre_epoch(self):
-        n=datetime(1970,1,1) - timedelta(days=365)
-        ts=-60*60*24*365
-        
-        self.assertAlmostEqual(ts, to_timestamp(n),5)
-        
+        n = DATE_TIME_EPOCH - timedelta(days=365)
+        ts = -60 * 60 * 24 * 365
+
+        self.assertAlmostEqual(ts, to_timestamp(n), 5)
+
+        if not is_win:
+            self.assertAlmostEqual(ts, n.timestamp(), 5)
+
     def test_to_timestamp_pre_epoch_dst(self):
-        n=datetime(1970,1,1) - timedelta(days=180)
-        ts=-60*60*24*180
-        
-        self.assertAlmostEqual(ts, to_timestamp(n),5)
-        
+        n = DATE_TIME_EPOCH - timedelta(days=180)
+        ts = -60 * 60 * 24 * 180
+
+        self.assertAlmostEqual(ts, to_timestamp(n), 5)
+
+        if not is_win:
+            self.assertAlmostEqual(ts, n.timestamp(), 5)
+
     def test_from_timestamp(self):
-        self.assertEqual(from_timestamp(0),datetime(1970,1,1,tzinfo=timezone.utc))
-        
+        self.assertEqual(from_timestamp(0), DATE_TIME_EPOCH)
+
     def test_from_timestamp_past(self):
-        day=60*60*24
-        self.assertEqual(from_timestamp(day*3),datetime(1970,1,4,tzinfo=timezone.utc))
-        
+        day = 60 * 60 * 24
+        self.assertEqual(from_timestamp(day * 3), datetime(1970, 1, 4, tzinfo=timezone.utc))
+
     def test_from_timestamp_past_dst(self):
-        day=60*60*24
-        self.assertEqual(from_timestamp(day*100),datetime(1970,4,11,tzinfo=timezone.utc))
-                
+        day = 60 * 60 * 24
+        self.assertEqual(from_timestamp(day * 100), datetime(1970, 4, 11, tzinfo=timezone.utc))
+
     def test_from_timestamp_future(self):
-        day=60*60*24
-        self.assertEqual(from_timestamp(day*29220),datetime(2050,1,1,tzinfo=timezone.utc))
-                
+        day = 60 * 60 * 24
+        self.assertEqual(from_timestamp(day * 29220), datetime(2050, 1, 1, tzinfo=timezone.utc))
+
     def test_from_timestamp_future_dst(self):
-        day=60*60*24
-        self.assertEqual(from_timestamp(day*29320),datetime(2050,4,11,tzinfo=timezone.utc))
-        
+        day = 60 * 60 * 24
+        self.assertEqual(from_timestamp(day * 29320), datetime(2050, 4, 11, tzinfo=timezone.utc))


### PR DESCRIPTION
The problem is that in Windows `datetime.datetime.timestamp()` will raise an `OSError` for dates before the epoch of 1970-1-1 UTC or after some indeterminant epoch just above the year 3000. Many other functions in `datetime` and `time` rely on similarly broken OS functions. 

The provided functions `to_timestamp` and `from_timestamp` are meant to use time offsets to calculate what the timestamp should be. These don't fully work in Windows because they miscalculate daylight savings so are off by an hour for some dates:

```python
def to_timestamp(dt):
    return (dt - datetime(1970, 1, 1, tzinfo=dt.tzinfo)).total_seconds()

n=datetime(2050,1,1)  # winter time
ts=n.timestamp()
ts1=to_timestamp(n)
print(ts,ts1,ts-ts1) # difference of 0

n=datetime(2050,6,6)  # daylight saving time
ts=n.timestamp()
ts1=to_timestamp(n) # difference of 3600, ie. 1 hour
```

These functions appear to be correct in Linux since they resort to `datetime.datetime.timestamp()` which works there, and the tests assume test dates are UTC (Perhaps all date handling should be in UTC or converted to UTC when imported.) The functions almost work in Windows except for this DST problem.
