### PR TITLE
Fix for merge of boolean numeric fields

### DIFF
--- a/exetera/core/operations.py
+++ b/exetera/core/operations.py
@@ -368,7 +368,14 @@ def ordered_map_valid_stream(data_field, map_field, result_field,
     """
     result_data = np.zeros(chunksize, dtype=result_field.data.dtype)
 
-    empty_value = 0 if np.issubdtype(result_field.data.dtype, np.number) else b''
+    empty_value = None
+    if np.issubdtype(result_field.data.dtype, bool):
+        empty_value = False
+    elif np.issubdtype(result_field.data.dtype, np.number):
+        empty_value = 0
+    else:
+        empty_value = b''
+    # empty_value = 0 if np.issubdtype(result_field.data.dtype, np.number) else b''
 
     m_chunk, map_, m_max, m_off, m = first_untrimmed_chunk(map_field, chunksize)
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -913,7 +913,6 @@ class TestOrderedMap(unittest.TestCase):
         src_data.data.write(np.asarray([False, True, False, True, False, True], dtype=bool))
         dest_data = fields.NumericMemField(s, 'bool')
         ops.ordered_map_valid_stream(src_data, map_data, dest_data, -1, 4)
-        expected = [10, 30, 30, 0, 50, 50, 50, 60, 60]
         expected = [False, True, False, False, False, False, False, True, True]
         self.assertListEqual(dest_data.data[:].tolist(), expected)
         # print(dest_data.data[:])

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -905,6 +905,20 @@ class TestOrderedMap(unittest.TestCase):
         # print(dest_data.data[:])
 
 
+    def test_ordered_map_valid_stream_bool(self):
+        s = session.Session()
+        map_data = fields.NumericMemField(s, 'int32')
+        map_data.data.write(np.asarray([0, 1, 2, -1, 4, 4, 4, 5, 5], dtype=np.int32))
+        src_data = fields.NumericMemField(s, 'bool')
+        src_data.data.write(np.asarray([False, True, False, True, False, True], dtype=bool))
+        dest_data = fields.NumericMemField(s, 'bool')
+        ops.ordered_map_valid_stream(src_data, map_data, dest_data, -1, 4)
+        expected = [10, 30, 30, 0, 50, 50, 50, 60, 60]
+        expected = [False, True, False, False, False, False, False, True, True]
+        self.assertListEqual(dest_data.data[:].tolist(), expected)
+        # print(dest_data.data[:])
+
+
     def test_ordered_map_valid_stream(self):
         s = session.Session()
         map_data = fields.NumericMemField(s, 'int32')


### PR DESCRIPTION
Currently numeric fields can't be merged on all ordered merge paths
