### PR TITLE
propose a guess_dtype function in utils to fix the index size issue

### DIFF
--- a/exetera/core/session.py
+++ b/exetera/core/session.py
@@ -29,6 +29,7 @@ from exetera.core import validation as val
 from exetera.core import operations as ops
 from exetera.core import dataset as ds
 from exetera.core import dataframe as df
+from exetera.core import utils
 
 
 class Session(AbstractSession):
@@ -434,7 +435,7 @@ class Session(AbstractSession):
             dest_f.data.write(results)
             return results
         else:
-            results = np.zeros(len(spans) - 1, dtype='int64')
+            results = np.zeros(len(spans) - 1, dtype=utils.guess_dtype(length=len(spans)))
             predicate(spans, results)
             return results
 
@@ -467,7 +468,10 @@ class Session(AbstractSession):
             dest_f.data.write(results)
             return results
         else:
-            data_type = 'int32' if len(spans) < 2000000000 else 'int64'
+            if 'index' in predicate.__name__:
+                data_type = utils.guess_dtype(length=len(spans))
+            else:
+                data_type = utils.guess_dtype(src_dtype=target_.dtype)
             results = np.zeros(len(spans) - 1, dtype=data_type)
             predicate(spans, target_, results)
             return results

--- a/exetera/core/session.py
+++ b/exetera/core/session.py
@@ -435,7 +435,7 @@ class Session(AbstractSession):
             dest_f.data.write(results)
             return results
         else:
-            results = np.zeros(len(spans) - 1, dtype=utils.guess_dtype(length=len(spans)))
+            results = np.zeros(len(spans) - 1, dtype=utils.guess_dtype(length=spans[-1]))
             predicate(spans, results)
             return results
 
@@ -469,7 +469,7 @@ class Session(AbstractSession):
             return results
         else:
             if 'index' in predicate.__name__:
-                data_type = utils.guess_dtype(length=len(spans))
+                data_type = utils.guess_dtype(length=spans[-1])
             else:
                 data_type = utils.guess_dtype(src_dtype=target_.dtype)
             results = np.zeros(len(spans) - 1, dtype=data_type)

--- a/exetera/core/utils.py
+++ b/exetera/core/utils.py
@@ -425,9 +425,18 @@ def guess_dtype(src_dtype=None, length=None):
     The dtype is specified by two parameters: 1) the source data type, when copy the data from the source;
     or 2) the source data length, when calculating the index or span of the source.
 
-    :param src_dtype:
-    :param length:
-    :return: suggested data type as string
+    :param src_dtype: the data type of the source field, used in min/max type of operations.
+    :param length: the length of the source filed, used in 'index of' type of operations.
+    :return: suggested data type as string.
+
+    Example::
+
+    >>> src_field = df.create_numeric('num', 'int64').data.write([range(10000)])
+    >>> guess_dtype(src_dtype=src_field.data.dtype)
+    int64
+    >>> guess_dtype(length=len(src_file.data))
+    int32
+
     """
     if src_dtype is None and length is None:
         raise ValueError('Please specify at least one parameter to use the guess_dtype function.')

--- a/exetera/core/utils.py
+++ b/exetera/core/utils.py
@@ -418,4 +418,20 @@ def guess_encoding(filename):
         return "utf-8-sig"
     else:
         return "utf-8"
-    
+
+
+def guess_dtype(src_dtype=None, length=None):
+    """
+    The dtype is specified by two parameters: 1) the source data type, when copy the data from the source;
+    or 2) the source data length, when calculating the index or span of the source.
+
+    :param src_dtype:
+    :param length:
+    :return: suggested data type as string
+    """
+    if src_dtype is None and length is None:
+        raise ValueError('Please specify at least one parameter to use the guess_dtype function.')
+    elif length is not None:
+        return 'int32' if length < 2**32 else 'int64'
+    elif src_dtype is not None:
+        return str(src_dtype)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -828,8 +828,8 @@ class TestSessionAggregate(unittest.TestCase):
             results = s.apply_spans_index_of_min(spans, vals)
             self.assertListEqual([0, 2, 4, 8], results.tolist())
 
-            idx = np.zeros(2**32+1, dtype=np.int32)
-            vals = np.zeros(2**32+1, dtype=np.int32)
+            idx = np.zeros(2**32+1, dtype=np.int8)
+            vals = np.zeros(2**32+1, dtype=np.int8)
             spans = s.get_spans(idx)
             results = s.apply_spans_index_of_min(spans, vals)
             self.assertEqual(str(results.dtype), 'int64')
@@ -857,8 +857,8 @@ class TestSessionAggregate(unittest.TestCase):
             results = s.apply_spans_index_of_max(spans, vals)
             self.assertListEqual([0, 1, 3, 9], results.tolist())
 
-            idx = np.zeros(2**32+1, dtype=np.int32)
-            vals = np.zeros(2**32+1, dtype=np.int32)
+            idx = np.zeros(2**32+1, dtype=np.int8)
+            vals = np.zeros(2**32+1, dtype=np.int8)
             spans = s.get_spans(idx)
             results = s.apply_spans_index_of_max(spans, vals)
             self.assertEqual(str(results.dtype), 'int64')
@@ -870,7 +870,7 @@ class TestSessionAggregate(unittest.TestCase):
             results = s.apply_spans_index_of_first(spans)
             self.assertListEqual([0, 1, 3, 6], results.tolist())
 
-            idx = np.zeros(2**32+1, dtype=np.int32)
+            idx = np.zeros(2**32+1, dtype=np.int8)
             spans = s.get_spans(idx)
             results = s.apply_spans_index_of_first(spans)
             self.assertEqual(str(results.dtype), 'int64')
@@ -882,7 +882,7 @@ class TestSessionAggregate(unittest.TestCase):
             results = s.apply_spans_index_of_last(spans)
             self.assertListEqual([0, 2, 5, 9], results.tolist())
 
-            idx = np.zeros(2**32+1, dtype=np.int32)
+            idx = np.zeros(2**32+1, dtype=np.int8)
             spans = s.get_spans(idx)
             results = s.apply_spans_index_of_last(spans)
             self.assertEqual(str(results.dtype), 'int64')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ import unittest
 
 import numpy as np
 
-from exetera.core.utils import find_longest_sequence_of, to_escaped, bytearray_to_escaped, get_min_max
+from exetera.core.utils import find_longest_sequence_of, to_escaped, bytearray_to_escaped, get_min_max, guess_dtype
 
 class TestUtils(unittest.TestCase):
 
@@ -100,4 +100,20 @@ class TestUtils(unittest.TestCase):
             (min_value, max_value) = get_min_max(value_type)
             self.assertEqual(min_value, expected_min_max_values[value_type][0])
             self.assertEqual(max_value, expected_min_max_values[value_type][1])
+
+    def test_guess_dtype_nparray(self):
+        array = np.zeros(2**16, 'int16')
+        dtype = guess_dtype(src_dtype=array.dtype)
+        self.assertEqual('int16', dtype)
+        dtype = guess_dtype(length=len(array))
+        self.assertEqual('int32', dtype)
+        dtype = guess_dtype(src_dtype=array.dtype, length=len(array))  # length take precedence
+        self.assertEqual('int32', dtype)
+
+        array = np.zeros(2 ** 32+1, 'int32')
+        dtype = guess_dtype(src_dtype=array.dtype)
+        self.assertEqual('int32', dtype)
+        dtype = guess_dtype(length=len(array))
+        self.assertEqual('int64', dtype)
+
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -110,9 +110,9 @@ class TestUtils(unittest.TestCase):
         dtype = guess_dtype(src_dtype=array.dtype, length=len(array))  # length take precedence
         self.assertEqual('int32', dtype)
 
-        array = np.zeros(2 ** 32+1, 'int32')
+        array = np.zeros(2 ** 32+1, 'int8')
         dtype = guess_dtype(src_dtype=array.dtype)
-        self.assertEqual('int32', dtype)
+        self.assertEqual('int8', dtype)
         dtype = guess_dtype(length=len(array))
         self.assertEqual('int64', dtype)
 


### PR DESCRIPTION
#257 fix index size globally
#255 fix the bug in apply_span_index_of_min/max when dest is not specified and array length > 2**32