### PR TITLE
implement where api

### DIFF
--- a/exetera/core/abstract_types.py
+++ b/exetera/core/abstract_types.py
@@ -85,6 +85,10 @@ class Field(ABC):
     def unique(self, return_index=False, return_inverse=False, return_counts=False):
         raise NotImplementedError()
 
+    @staticmethod
+    def where(cond, a, b):
+        raise NotImplementedError()
+
 
 class Dataset(ABC):
     """

--- a/exetera/core/fields.py
+++ b/exetera/core/fields.py
@@ -39,6 +39,23 @@ def isin(field:Field, test_elements:Union[list, set, np.ndarray]):
     return ret
 
 
+def where(cond, a, b):
+    if isinstance(cond, list) or (isinstance(cond, np.ndarray) and cond.dtype == 'bool'):
+        cond = cond
+    elif isinstance(cond, Field):
+        if cond.indexed:
+            raise NotImplementedError("Where does not support indexed string fields at present")
+        cond = cond.data[:]
+    elif callable(cond):
+        raise NotImplementedError("fields.where doesn't support callable cond")
+
+    if isinstance(a, Field):
+        a = a.data[:]
+    if isinstance(b, Field):
+        b = b.data[:]
+    return np.where(cond, a, b)
+
+
 class HDF5Field(Field):
     def __init__(self, session, group, dataframe, write_enabled=False):
         super().__init__()
@@ -142,6 +159,31 @@ class HDF5Field(Field):
     def _ensure_valid(self):
         if not self._valid_reference:
             raise ValueError("This field no longer refers to a valid underlying field object")
+
+    def where(self, cond, b, inplace=False):
+
+        if callable(cond):
+            cond = cond(self.data[:])
+        elif isinstance(cond, list) or (isinstance(cond, np.ndarray) and cond.dtype == 'bool'):
+            cond = cond
+        elif isinstance(cond, Field):
+            if cond.indexed:
+                raise NotImplementedError("Where does not support indexed string fields at present")
+            cond = cond.data[:]
+        else:
+            raise TypeError("'cond' parameter needs to be either callable lambda function, or boolean ndarray, or NumericMemField")
+
+        if isinstance(b, str):
+            b = b.encode()
+        if isinstance(b, Field):
+            b = b.data[:]
+
+        result = np.where(cond, self.data[:], b)
+
+        if inplace:
+            self.data.clear()
+            self.data.write(result)
+        return result
 
 
 class MemoryField(Field):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2169,6 +2169,273 @@ class TestFieldIsIn(SessionTestCase):
                 np.testing.assert_array_equal(expected, result)
 
 
+MODULE_WHERE_TESTS = [
+    (lambda f: f > 5, [-1, 2, 3, 5, 9, 5, 8, 6, 4, 7, 0], 'int32', 0, None),
+    (
+        [False, False, False, False,  True, False,  True,  True, False, True, False],
+        [-1, 2, 3, 5, 9, 5, 8, 6, 4, 7, 0], 'int32',
+        9, None
+    ),
+    (
+        [False, False, False, False,  True, False,  True,  True, False, True, False],
+        [-1, 2, 3, 5, 9, 5, 8, 6, 4, 7, 0], 'int32',
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 'int64',
+    ),
+]
+
+INSTANCE_WHERE_NUMERIC_TESTS = [
+    (lambda f: f > 5, [-1, 2, 3, 5, 9, 5, 8, 6, 4, 7, 0], 'int32', 0, None),
+    (lambda f: f > 5, [-1, 2, 3, 5, 9, 5, 8, 6, 4, 7, 0], 'int32', 9, None),
+    (lambda f: f > 5, [-1, 2, 3, 5, 9, 5, 8, 6, 4, 7, 0], 'int32', -1, None),
+    (lambda f: f > 5, [-1, 2, 3, 5, 9, 5, 8, 6, 4, 7, 0], 'int32', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 'int32'),
+    (lambda f: f > 5, [-1, 2, 3, 5, 9, 5, 8, 6, 4, 7, 0], 'int32', [9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9], 'int64'),
+    (lambda f: f > 5, [-1, 2, 3, 5, 9, 5, 8, 6, 4, 7, 0], 'int32', [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0], 'float32'),
+    # (
+    #     [False, False, False, False,  True, False,  True,  True, False, True, False],
+    #     [-1, 2, 3, 5, 9, 5, 8, 6, 4, 7, 0],
+
+    # )
+
+]
+
+def where_oracle(cond, a, b):
+    if callable(cond):
+        if isinstance(a, fields.Field):
+            cond = cond(a.data[:])
+        elif isinstance(a, list):
+            cond = cond(np.array(a))
+        elif isinstance(a, np.ndarray):
+            cond = cond(a)
+    return np.where(cond, a, b)
+
+
+class TestFieldWhereFunctions(SessionTestCase):
+
+    @parameterized.expand(MODULE_WHERE_TESTS)
+    def test_module_field_where(self, cond, a_field_data, a_field_dtype, b_data, b_dtype):
+        """
+        Test `where` for the numeric fields using `fields.where` function and the object's method.
+        """
+        a_field = self.setup_field(self.df, "create_numeric", "af", (a_field_dtype,), {}, a_field_data)
+
+
+        expected_result = where_oracle(cond, a_field_data, b_data)
+
+        with self.subTest("Test module function: numeric field and single numeric value"):
+            if callable(cond):
+                with self.assertRaises(NotImplementedError) as context:
+                    result = fields.where(cond, a_field, b_data)
+                self.assertEqual(str(context.exception), "fields.where doesn't support callable cond")
+            else:
+                result = fields.where(cond, a_field, b_data)
+                np.testing.assert_array_equal(expected_result, result)
+
+        if b_dtype is not None:
+            b_field = self.setup_field(self.df, "create_numeric", "bf", (b_dtype,), {}, b_data)
+
+            with self.subTest("Test module function: numeric field and single numeric value"):
+                if callable(cond):
+                    with self.assertRaises(NotImplementedError) as context:
+                        result = fields.where(cond, a_field, b_field)
+                    self.assertEqual(str(context.exception), "fields.where doesn't support callable cond")
+                else:
+                    result = fields.where(cond, a_field, b_field)
+                    np.testing.assert_array_equal(expected_result, result)
+
+
+    @parameterized.expand(INSTANCE_WHERE_NUMERIC_TESTS)
+    def test_instance_field_where(self, cond, a_field_data, a_field_dtype, b_data, b_dtype):
+        a_field = self.setup_field(self.df, "create_numeric", "af", (a_field_dtype,), {}, a_field_data)
+
+        expected_result = where_oracle(cond, a_field_data, b_data)
+
+        with self.subTest("Test field method: numeric field and single numeric value"):
+            result = a_field.where(cond, b_data)
+            # self.assertEqual(result.dtype, )
+            np.testing.assert_array_equal(expected_result, result)
+
+
+
+# (1) data type of return result, if it's 
+
+    # def _test_module_where(self, create_field_fn, predicate, if_true, if_false, expected):
+    #     bio = BytesIO()
+    #     with session.Session() as s:
+    #         src = s.open_dataset(bio, 'w', 'src')
+    #         df = src.create_dataframe('df')
+    #         f = create_field_fn(df, 'foo')
+
+    #         with self.subTest("testing module where"):
+    #             r = fields.where(predicate(f), if_true, if_false)
+    #             self.assertEqual(r.tolist(), expected)
+
+    # def _test_instance_where(self, create_field_fn, predicate, if_false, expected):
+    #     bio = BytesIO()
+    #     with session.Session() as s:
+    #         src = s.open_dataset(bio, 'w', 'src')
+    #         df = src.create_dataframe('df')
+    #         f = create_field_fn(df, 'foo')
+
+    #         with self.subTest("testing field where"):
+    #             r = f.where(predicate(f), if_false)
+    #             self.assertEqual(r.tolist(), expected)
+    #         with self.subTest("testing field where with predicate"):
+    #             r = f.where(lambda f2: predicate(f2), if_false)
+    #             self.assertEqual(r.tolist(), expected)
+    #         with self.subTest("testing inplace field where"):
+    #             r = f.where(predicate(f), if_false, inplace=True)
+    #             self.assertEqual(list(f.data[:]), expected)
+
+    # def test_field_where_numeric_int32(self):
+    #     def create_numeric(df, name):
+    #         f = df.create_numeric(name, 'int32')
+    #         f.data.write(np.asarray([-1, 2, 3, 5, 9, 5, 8, 6, 4, 7, 0], dtype=np.int32))
+    #         return f
+
+    #     self._test_module_where(create_numeric, lambda f: f > 5, 1, 0,
+    #                             [0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 0])
+    #     self._test_module_where(create_numeric, lambda f: f > 5, 1, 9,
+    #                             [9, 9, 9, 9, 1, 9, 1, 1, 9, 1, 9])
+    #     self._test_module_where(create_numeric, lambda f: f > 5, 1, -1,
+    #                             [-1, -1, -1, -1, 1, -1, 1, 1, -1, 1, -1])
+
+    #     self._test_instance_where(create_numeric, lambda f: f > 5, 0,
+    #                               [0, 0, 0, 0, 9, 0, 8, 6, 0, 7, 0])
+    #     self._test_instance_where(create_numeric, lambda f: f > 5, 9,
+    #                               [9, 9, 9, 9, 9, 9, 8, 6, 9, 7, 9])
+    #     self._test_instance_where(create_numeric, lambda f: f > 5, -1,
+    #                               [-1, -1, -1, -1, 9, -1, 8, 6, -1, 7, -1])
+
+    # def test_field_where_numeric_float32(self):
+    #     def create_numeric(df, name):
+    #         f = df.create_numeric(name, 'float32')
+    #         f.data.write(np.asarray([1e-7, 0.24, 1873.0, -0.0088, 227819.38457, np.nan, 0.0],
+    #                                 dtype=np.float32))
+    #         return f
+
+    #     self._test_module_where(create_numeric, lambda f: np.isnan(f.data[:]), 1, 0,
+    #                             [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0])
+        # self._test_module_where(create_numeric, lambda f: f > 5, 1, 9,
+        #                         [9, 9, 9, 9, 1, 9, 1, 1, 9, 1, 9])
+        # self._test_module_where(create_numeric, lambda f: f > 5, 1, -1,
+        #                         [-1, -1, -1, -1, 1, -1, 1, 1, -1, 1, -1])
+        #
+        # self._test_instance_where(create_numeric, lambda f: f > 5, 0,
+        #                           [0, 0, 0, 0, 9, 0, 8, 6, 0, 7, 0])
+        # self._test_instance_where(create_numeric, lambda f: f > 5, 9,
+        #                           [9, 9, 9, 9, 9, 9, 8, 6, 9, 7, 9])
+        # self._test_instance_where(create_numeric, lambda f: f > 5, -1,
+        #                           [-1, -1, -1, -1, 9, -1, 8, 6, -1, 7, -1])
+
+    # def test_field_where_categorical(self):
+    #     def create_categorical(df, name):
+    #         f = df.create_categorical(name, nformat='int8', key={'x': 0, 'y': 1, 'xy': 2})
+    #         f.data.write(np.asarray([0, 2, 1, 2, 0, 1, 1, 2, 1]))
+    #         return f
+
+    #     self._test_module_where(create_categorical, lambda f: f == 2, 1, 0,
+    #                             [0, 1, 0, 1, 0, 0, 0, 1, 0])
+
+    #     self._test_instance_where(create_categorical, lambda f: f != 2, -1,
+    #                               [0, -1, 1, -1, 0, 1, 1, -1, 1])
+
+    # def test_field_where_fixed_string(self):
+    #     def create_fixed_string(df, name):
+    #         f = df.create_fixed_string(name, 6)
+    #         f.data.write(np.asarray(['foo', '"foo"', '', 'bar', 'barn', 'bat'], dtype='S6'))
+    #         return f
+
+    #     self._test_module_where(create_fixed_string, lambda f: np.char.str_len(f.data[:]) > 3,
+    #                             'boo', '_far',
+    #                             ['_far', 'boo', '_far', '_far', 'boo', '_far'])
+    #                             # [b'_far', b'boo', b'_far', b'_far', b'boo', b'_far'])
+
+    #     self._test_instance_where(create_fixed_string, lambda f: np.char.str_len(f.data[:]) > 3,
+    #                               'foobar',
+    #                               [b'foobar', b'"foo"', b'foobar', b'foobar', b'barn', b'foobar'])
+
+
+    # def test_field_where_indexed_string(self):
+    #     def create_indexed_string(df, name):
+    #         f = df.create_indexed_string(name)
+    #         f.data.write(['foo', '"foo"', '', 'bar', 'barn', 'bat'])
+    #         return f
+
+    #     self._test_module_where(create_indexed_string, lambda f: np.char.str_len(f.data[:]) > 3,
+    #                             'boo', '_far', ['_far', 'boo', '_far', '_far', 'boo', '_far'])
+
+    #     self._test_module_where(create_indexed_string, lambda f: (f.indices[1:] - f.indices[:-1]) > 3,
+    #                             'boo', '_far', ['_far', 'boo', '_far', '_far', 'boo', '_far'])
+
+
+    # def test_module_where_numeric(self):
+    #     input_data = [1, 2, 3, 5, 9, 8, 6, 4, 7, 0]
+    #     data = np.asarray(input_data, dtype=np.int32)
+    #     bio = BytesIO()
+    #     with session.Session() as s:
+    #         src = s.open_dataset(bio, 'w', 'src')
+    #         df = src.create_dataframe('df')
+    #         f = df.create_numeric('foo', 'int32')
+    #         f.data.write(data)
+    #
+    #         r = fields.where(f > 5, 1, 0)
+    #         self.assertEqual(r.tolist(), [0,0,0,0,1,1,1,0,1,0])
+    #
+    # def test_instance_where_numeric(self):
+    #     input_data = [1,2,3,5,9,8,6,4,7,0]
+    #     data = np.asarray(input_data, dtype=np.int32)
+    #     bio = BytesIO()
+    #     with session.Session() as s:
+    #         src = s.open_dataset(bio, 'w', 'src')
+    #         df = src.create_dataframe('df')
+    #         f = df.create_numeric('foo', 'int32')
+    #         f.data.write(data)
+    #         r = f.where(f > 5, 0)
+    #         self.assertEqual(r.tolist(), [0,0,0,0,9,8,6,0,7,0])
+    #
+    # def test_instance_where_numeric_inplace(self):
+    #     input_data = [1,2,3,5,9,8,6,4,7,0]
+    #     data = np.asarray(input_data, dtype=np.int32)
+    #     bio = BytesIO()
+    #     with session.Session() as s:
+    #         src = s.open_dataset(bio, 'w', 'src')
+    #         df = src.create_dataframe('df')
+    #         f = df.create_numeric('foo', 'int32')
+    #         f.data.write(data)
+    #
+    #         r = f.where(f > 5, 0)
+    #         self.assertEqual(list(f.data[:]), [1,2,3,5,9,8,6,4,7,0])
+    #         r = f.where(f > 5, 0, inplace=True)
+    #         self.assertEqual(list(f.data[:]), [0,0,0,0,9,8,6,0,7,0])
+    #
+    # def test_instance_where_with_callable(self):
+    #     input_data = [1,2,3,5,9,8,6,4,7,0]
+    #     data = np.asarray(input_data, dtype=np.int32)
+    #     bio = BytesIO()
+    #     with session.Session() as s:
+    #         src = s.open_dataset(bio, 'w', 'src')
+    #         df = src.create_dataframe('df')
+    #         f = df.create_numeric('foo', 'int32')
+    #         f.data.write(data)
+    #
+    #         r = f.where(lambda x: x > 5, 0)
+    #         self.assertEqual(r.tolist(), [0,0,0,0,9,8,6,0,7,0])
+
+    # def test_where_bool_condition(self):
+    #     input_data = [1,2,3,5,9,8,6,4,7,0]
+    #     data = np.asarray(input_data, dtype=np.int32)
+    #     bio = BytesIO()
+    #     with session.Session() as s:
+    #         src = s.open_dataset(bio, 'w', 'src')
+    #         df = src.create_dataframe('df')
+    #         f = df.create_numeric('foo', 'int32')
+    #         f.data.write(data)
+
+    #         cond = np.array([False,False,True,True, False, True, True, False, False, True])
+    #         r = f.where(cond, 0)
+    #         self.assertEqual(r.tolist(), [0,0,3,5,0,8,6,0,0,0])
+
+
 class TestFieldModuleFunctions(SessionTestCase):
 
     @parameterized.expand(DEFAULT_FIELD_DATA)


### PR DESCRIPTION
fix #224 

TODO:
(1) Accept types Field, np.ndarray, list, tuple, for where function and methods
(2) where always returns a MemField, in case of inplace return self after changing internals to match type if necessary, otherwise returning fresh field
(3) categorical is typed down to integer, treat timestamp as float64 fields
For checking for multiple types: isinstance(cond, (list, tuple, np.ndarray))